### PR TITLE
Documentation cleanup

### DIFF
--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -1,17 +1,17 @@
 .. _expl_new_oidc:
 
-Why make a new OIDC library ?
+Why make a new OIDC library?
 =============================
 
 We decided to roll our own OIDC integration with Django, and that is not a small work. As such we first performed an analysis of the existing libraries, evaluating whether or not we should contribute to them or implement our own.
 
 In this section you will find the results of this analysis. We collected our data during the first months of 2023.
 
-Here are our criteria :
+Here are our criteria:
 
 * do you need a custom authentication backend to work ? Our use case includes multi-tenant setup through `django-siteprefs <https://pypi.org/project/django-siteprefs/>`_
-* is security sensitive code based on a well known, well maintained library ?
-* is it still maintained ?
+* is security sensitive code based on a well known, well maintained library?
+* is it still maintained?
 * does it supports *Bearer* authentication (for ``django-rest-framework``).
 
 
@@ -24,12 +24,12 @@ be used for OIDC usages.
 `django-auth-oidc <https://gitlab.com/aiakos/django-auth-oidc>`_
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Advantages** :
+**Advantages**:
 
 - Goes well with `django-siteprefs <https://pypi.org/project/django-siteprefs/>`_
 - Nice hook system that is very very flexible and works well
 
-**Drawbacks** :
+**Drawbacks**:
 
 - The OIDC implementation is based on a custom lib `python-openid-connect <https://gitlab.com/aiakos/python-openid-connect>`_ (which is itself based on ``jose``)
 - No *Bearer* authentication
@@ -40,7 +40,7 @@ be used for OIDC usages.
 
 This library is based on ``django-auth-oidc`` and adds some glue to allow more features.
 
-**Advantages** :
+**Advantages**:
 
 - Modular architecture which is very flexible
 - Does support *bearer* and *confidential* clients
@@ -60,7 +60,7 @@ This library is based on ``django-auth-oidc`` and adds some glue to allow more f
 **Drawbacks**
 
 - It seems that adding OIDC features will be complicated as they seem to want to keep their library *"as minimal/lightweight as possible"*
-- The project seems dead ?
+- The project seems dead?
 
 
 `django-oidc <https://github.com/py-pa/django-oidc>`_
@@ -188,7 +188,7 @@ you have nothing to handle.
 Direct logout
 ~~~~~~~~~~~~~
 
-OIDC specification : https://openid.net/specs/openid-connect-rpinitiated-1_0.html
+OIDC specification: https://openid.net/specs/openid-connect-rpinitiated-1_0.html
 
 The direct logout is the first use case, the *simple* one. The active SSO user is currently on your Django managed website,
 he wants to disconnect.
@@ -224,7 +224,7 @@ You can extend this view by defining a **HOOK_USER_LOGOUT** which runs just befo
 Back-channel logout
 ~~~~~~~~~~~~~~~~~~~
 
-OIDC specification : https://openid.net/specs/openid-connect-backchannel-1_0.html
+OIDC specification: https://openid.net/specs/openid-connect-backchannel-1_0.html
 
 The **SSO Server client configuration** for your application will need to know the Back-Channel url on your Django application, this url
 is by default **``<absolute url of your website>/<url prefix for this module if any>/back_channel_logout/``**.
@@ -266,9 +266,9 @@ chained logouts. A Back-Channel Logout will never be blocked by a browser securi
 Front-channel logout
 ~~~~~~~~~~~~~~~~~~~~
 
-OIDC specification : https://openid.net/specs/openid-connect-frontchannel-1_0.html
+OIDC specification: https://openid.net/specs/openid-connect-frontchannel-1_0.html
 
-**Not Implemented : this documentation for front channel logout refers to a future feature.** As Keycloak server does not implement front channel
+**Not Implemented: this documentation for front channel logout refers to a future feature.** As Keycloak server does not implement front channel
 logout we did not implement it yet. This implementation will occurs as soon as we find a reliable way to test it.
 
 As stated above the front channel logout is less reliable than the Back Channel logout, but you may only have this option
@@ -310,7 +310,7 @@ Django website to be only an OIDC client (not server) and we did not implement t
 About caching
 =============
 
-This library depends on **Django cache system**. Why does an OIDC client depends on a cache ?
+This library depends on **Django cache system**. Why does an OIDC client depends on a cache?
 
 The OIDC protocol has a lot of states (as several messages are exchanged and some elements are send back to validate that the response
 goes with your request, or that no one tried to *replay* the exchange) and also needs to store external elements (think of public cryptographic

--- a/docs/explanation.rst
+++ b/docs/explanation.rst
@@ -3,7 +3,7 @@
 Why make a new OIDC library ?
 =============================
 
-We decided to role our own OIDC integration with Django, and that is not a small work. As such we first performed an analysis of the existing libraries, evaluating whether or not we should contribute to them or implement our own.
+We decided to roll our own OIDC integration with Django, and that is not a small work. As such we first performed an analysis of the existing libraries, evaluating whether or not we should contribute to them or implement our own.
 
 In this section you will find the results of this analysis. We collected our data during the first months of 2023.
 
@@ -111,7 +111,7 @@ a remote web service using OIDC, not using an human account but a service accoun
 The multi-tenant feature means handling several OIDC providers, it is not uncommon to allow several identity providers on your login page.
 A good OIDC client should facilitate the configuration mechanisms for handling several very different OIDC connectors. Using both a
 classical web application (generating HTML pages) and a REST API on the same Django application could also be managed with different OIDC credentials,
-and the OIDC client configuration should let you use différent credentials on theses applications sections with ease.
+and the OIDC client configuration should let you use different credentials on theses applications sections with ease.
 
 OIDC Logouts
 ------------
@@ -255,7 +255,7 @@ not have the ``sid`` session identifier it means that all sessions of the ``sub`
 To be able to destroy the user session based on this ``sid`` or ``sub`` we have to ensure that we can find back any local Django session
 by theses identifiers, which are not the Django session identifier.
 This is the main reason of having an ``OIDCSession`` model managed by this library, it can be used to find and destroy all sessions
-associated with a ``sub`` identifier or for the ``sid`` search in the session_state attribute of this model. Check also the exaplanations
+associated with a ``sub`` identifier or for the ``sid`` search in the session_state attribute of this model. Check also the explanations
 on **cache management** below.
 
 If you can use the Backchannel logout, i.e. it is supported by the SSO server and you can transmits the right url to use to get a working
@@ -310,7 +310,7 @@ Django website to be only an OIDC client (not server) and we did not implement t
 About caching
 =============
 
-This library depends on **Django cache system**. Why do an OIDC client depends on a cache ?
+This library depends on **Django cache system**. Why does an OIDC client depends on a cache ?
 
 The OIDC protocol has a lot of states (as several messages are exchanged and some elements are send back to validate that the response
 goes with your request, or that no one tried to *replay* the exchange) and also needs to store external elements (think of public cryptographic

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -5,7 +5,7 @@ This library provides a hook system to call custom code. Hooks are configured on
 In this guide we will setup two hook function that add login/logout messages using `Django's message system
 <https://docs.djangoproject.com/en/stable/ref/contrib/messages/>`_.
 
-First, if you don't already have a Python module holding OIDC related code in your projet, create a file
+First, if you don't already have a Python module holding OIDC related code in your project, create a file
 named ``oidc.py`` next to your settings.
 
 Add in those two functions :
@@ -66,18 +66,18 @@ Make sure that you modified your template to display messages. See
 Customize how token data is mapped to User attributes
 =====================================================
 
-When a user succesfully logs-in, we provide an implementation that maps the received OIDC token to
+When a user successfully logs-in, we provide an implementation that maps the received OIDC token to
 ``User`` model instances. The default implementation extracts the email and the username from the token
 and uses it to create a User instance.
 
-However you can implement more complex behaviour by specifying a :ref:`hook_get_user` in your setting
+However you can implement more complex behavior by specifying a :ref:`hook_get_user` in your setting
 configuration. In this guide we will look at the ``groups`` attribute in a userinfo token and set the
 :attr:`is_staff <django.contrib.auth.models.User.is_staff>` attribute depending on the value.
 
-First, if you don't already have a Python module holding OIDC related code in your projet, create a file
+First, if you don't already have a Python module holding OIDC related code in your project, create a file
 named ``oidc.py`` next to your settings.
 
-Add in a function that takes one arguments : a list of tokens received during the authentication process. There are multiple tokens because OIDC defines multiple tokens, and some providers put the information in one token an some in an other one :
+Add in a function that takes one argument: a list of tokens received during the authentication process. There are multiple tokens because OIDC defines multiple tokens, and some providers put the information in one token and some in another one :
 * the userinfo token
 * the access token
 
@@ -260,14 +260,14 @@ Here is an example of a login button redirecting the user to the page named "pro
             query_string = urllib.parse.urlencode({"next": reverse("profile")})
             return redirect(f"{base_url}?{query_string}")
 
-However you will need to tweak the settings according to your use-case. You should take a look at  :ref:`login_redirection_requires_https` and :ref:`login_uris_redirect_allowed_hosts`.
+However you will need to tweak the settings according to your use-case. You should take a look at :ref:`login_redirection_requires_https` and :ref:`login_uris_redirect_allowed_hosts`.
 
 TODO: RedirectDemo now exists, where do I connect it?
 
 Use multiple identity providers
 ===============================
 
-This library natively supports multiples identity providers.
+This library natively supports multiple identity providers.
 
 You already have to specify a provider name when you configure your settings (either automatically by using a provider, or :ref:`manually <provider-class-setting>`).
 
@@ -309,4 +309,4 @@ This will create 4 views for each provider in your URL configuration. They all h
 * ``<op_name>-backchannel-logout``
 
 Since settings are local to a provider, you can also provide different :ref:`hook_get_user` for each to implement custom
-behaviours based on which identity provider a user is coming from.
+behaviors based on which identity provider a user is coming from.

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -8,7 +8,7 @@ In this guide we will setup two hook function that add login/logout messages usi
 First, if you don't already have a Python module holding OIDC related code in your project, create a file
 named ``oidc.py`` next to your settings.
 
-Add in those two functions :
+Add in those two functions:
 
 .. code-block:: python
 
@@ -27,7 +27,7 @@ Add in those two functions :
 Next, we plug those functions in the library configuration. In your ``settings.py`` you should set the
 ``hook_user_login`` and ``hook_user_logout`` to point to those two functions.
 
-Here is how it looks if we extend the configuration made in :ref:`Configure the library` :
+Here is how it looks if we extend the configuration made in :ref:`Configure the library`:
 
 .. code-block:: python
     :caption: settings.py
@@ -50,14 +50,14 @@ Here is how it looks if we extend the configuration made in :ref:`Configure the 
             "oidc_cache_provider_metadata": True,
 
             # New configuration
-            'hook_user_login' : 'my_project.oidc.login_function',
-            'hook_user_logout' : 'my_project.oidc.logout_function'
+            'hook_user_login': 'my_project.oidc.login_function',
+            'hook_user_logout': 'my_project.oidc.logout_function'
         },
 
 
 See :ref:`Hook settings <settings_hook>` for more information on the function path syntax.
 
-You should now see a message on login/logout ! 🎉
+You should now see a message on login/logout! 🎉
 
 Make sure that you modified your template to display messages. See
 :func:`django:django.contrib.messages.get_messages` for more information.
@@ -77,7 +77,7 @@ configuration. In this guide we will look at the ``groups`` attribute in a useri
 First, if you don't already have a Python module holding OIDC related code in your project, create a file
 named ``oidc.py`` next to your settings.
 
-Add in a function that takes one argument: a list of tokens received during the authentication process. There are multiple tokens because OIDC defines multiple tokens, and some providers put the information in one token and some in another one :
+Add in a function that takes one argument: a list of tokens received during the authentication process. There are multiple tokens because OIDC defines multiple tokens, and some providers put the information in one token and some in another one:
 * the userinfo token
 * the access token
 
@@ -118,7 +118,7 @@ Let's start our implementation by reusing the default implementation provided by
         }
 
 Since we are familiar with OIDC tokens, we know that we want to check the ``groups`` claim, and look for a
-group named *admin*. If you are not familiar with the claims available in your tokens, print them !
+group named *admin*. If you are not familiar with the claims available in your tokens, print them!
 
 .. code-block:: python
 
@@ -136,17 +136,17 @@ group named *admin*. If you are not familiar with the claims available in your t
 
 To have this function called instead of the default one, you need to modify your settings so that :ref:`hook_get_user` points to the function that we just wrote.
 
-The value of this setting should be : ``<my_app>.oidc:login_function`` (see :ref:`Hook settings <settings_hook>` for more information on this syntax).
+The value of this setting should be: ``<my_app>.oidc:login_function`` (see :ref:`Hook settings <settings_hook>` for more information on this syntax).
 
 If you configured your settings manually (without using the providers system), you can add the key directly.
 
-Edit your configuration to add the following key to your provider settings :
+Edit your configuration to add the following key to your provider settings:
 
 .. code-block:: python
 
     DJANGO_PYOIDC = {
-        'sso' : {
-            'hook_get_user' : 'my_app.oidc:get_huser' # <- my_app is a placeholder, alter it for your root module
+        'sso': {
+            'hook_get_user': 'my_app.oidc:get_huser' # <- my_app is a placeholder, alter it for your root module
         }
     }
 
@@ -164,7 +164,7 @@ In this guide, we will start from what we did in :ref:`Customize how token data 
 
 By the specification, the audience in a token is a list of strings or a single string,
 so let's .....
-Since we already defined our client ID in the settings, we fetch it from there ! This example assumes that your provider is named `keycloak`.
+Since we already defined our client ID in the settings, we fetch it from there! This example assumes that your provider is named `keycloak`.
 
 
 .. code-block:: python
@@ -203,7 +203,7 @@ We will start from what we did in :ref:`Customize how token data is mapped to Us
 
 In the *userinfo token* we can expect to find a 'groups' key (if available) and use it to query Django Groups models.
 
-Here is how to do it :
+Here is how to do it:
 
 .. code-block:: python
 
@@ -242,7 +242,7 @@ By default the ``success_redirect`` url defined in your provider is used to redi
 If you want a more complex redirection (like maybe a dynamic redirection based on the current user navigation)
 you can build something TODO:
 
-Here is an example of a login button redirecting the user to the page named "profile" :
+Here is an example of a login button redirecting the user to the page named "profile":
 
 .. code-block:: python
 
@@ -255,7 +255,7 @@ Here is an example of a login button redirecting the user to the page named "pro
         http_method_names = ["get"]
 
         def get(self):
-            # From : https://realpython.com/django-redirects/#passing-parameters-with-redirects
+            # From: https://realpython.com/django-redirects/#passing-parameters-with-redirects
             base_url = reverse("my-oidc-provider-login")
             query_string = urllib.parse.urlencode({"next": reverse("profile")})
             return redirect(f"{base_url}?{query_string}")
@@ -271,23 +271,23 @@ This library natively supports multiple identity providers.
 
 You already have to specify a provider name when you configure your settings (either automatically by using a provider, or :ref:`manually <provider-class-setting>`).
 
-In a multi-provider setup, the settings look like this :
+In a multi-provider setup, the settings look like this:
 
 .. code-block:: python
 
     DJANGO_PYOIDC = {
-        'oidc_provider_name_1' : {
-            'client_id' : '' # <- provider 1 settings here
+        'oidc_provider_name_1': {
+            'client_id': '' # <- provider 1 settings here
         }
-        'oidc_provider_name_2' : {
-            'client_id' : '' # <- provider 2 settings here
+        'oidc_provider_name_2': {
+            'client_id': '' # <- provider 2 settings here
         }
      }
 
 Then you have to include all your provider url configuration in your ``urlpatterns``. Since view names includes the identity provider name,
 they should not collide.
 
-Here is an example of such a configuration :
+Here is an example of such a configuration:
 
 .. code-block:: python
     :caption: urls.py
@@ -301,7 +301,7 @@ Here is an example of such a configuration :
 
 You can then use those view names to redirect a user to one or the other provider.
 
-This will create 4 views for each provider in your URL configuration. They all have a name that derives from the ``op_name`` that you used to create your provider :
+This will create 4 views for each provider in your URL configuration. They all have a name that derives from the ``op_name`` that you used to create your provider:
 
 * ``<op_name>-login``
 * ``<op_name>-logout``

--- a/docs/how-to.rst
+++ b/docs/how-to.rst
@@ -87,9 +87,9 @@ Let's start our implementation by reusing the default implementation provided by
 
 .. code-block:: python
 
-    from django.contrib.auth import get_user_model
     from django_pyoidc import get_user_by_email
-    def get_user(tokens):
+
+    def get_user(client, tokens):
         # Here, we reuse the implementation of our library
         user = get_user_by_email(tokens)
         return user
@@ -122,10 +122,10 @@ group named *admin*. If you are not familiar with the claims available in your t
 
 .. code-block:: python
 
-    from django.contrib.auth import get_user_model
+    from django_pyoidc import get_user_by_email
     from django_pyoidc.utils import extract_claim_from_tokens
 
-    def get_user(tokens):
+    def get_user(client, tokens):
         # Here, we reuse the implementation of our library
         user = get_user_by_email(tokens)
         groups = extract_claim_from_tokens('groups', tokens)
@@ -170,12 +170,12 @@ Since we already defined our client ID in the settings, we fetch it from there !
 .. code-block:: python
 
 
-    from django.contrib.auth import get_user_model
+    from django_pyoidc import get_user_by_email
     from django_pyoidc.utils import extract_claim_from_tokens
     from django.core.exceptions import PermissionDenied
     from django.conf import settings
 
-    def get_user(tokens):
+    def get_user(client, tokens):
         audiences = extract_clam_from_tokens("aud", tokens)
 
         # Perform audience check
@@ -208,10 +208,10 @@ Here is how to do it :
 .. code-block:: python
 
 
-    from django.contrib.auth import get_user_model
+    from django_pyoidc import get_user_by_email
     from django_pyoidc.utils import extract_claim_from_tokens
 
-    def get_user(tokens):
+    def get_user(client, tokens):
         # Here, we reuse the implementation of our library
         user = get_user_by_email(tokens)
         groups = extract_claim_from_tokens('groups', tokens)

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -6,7 +6,7 @@ Views
     When instantiating a view from this library (ie through django's 'as_view()') you **must** set the named argument ``op_name`` to point to a valid ``DJANGO_PYOIDC`` settings entry.
     If you use :ref:`Providers` then this behaviour is automatically implemented.
 
-    Here is an example :
+    Here is an example:
 
     .. code-block:: python
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -28,7 +28,7 @@ provider_class
 **Default** : "django_pyoidc.providers.Provider"
 
 Use this setting to plug in a provider class that will be used to generate the settings of your identity provider.
-Some providers expect to receives custom arguments : you should defines them as settings.
+Some providers expect to receive custom arguments : you should define them as settings.
 
 For example, the ``Keycloak10Provider`` can use two arguments : ``keycloak_base_uri`` and ``keycloak_realm``. If you wish to use them, define them in ``DJANGO_PYOIDC`` as your identity provider setting.
 
@@ -48,7 +48,7 @@ client_secret
 This setting configures the client secret used to authenticate your application with an identity provider.
 
 .. note::
-    If you only have a client_id and not client_secret it means your OIDC client (application) was defined as a public application, which is normally only done for javascript SLA applications. A regular web application should have a client_secret, and an API backend application too.
+    If you only have a client_id and not client_secret it means your OIDC client (application) was defined as a public application, which is normally only done for JavaScript SLA applications. A regular web application should have a client_secret, and an API backend application too.
 
 
 client_id
@@ -61,12 +61,12 @@ use_introspection_on_access_tokens
 
 **Default** : ``True``
 
-This setting is enabled by default on Django Rest Framework authentication (when you use drf for the key in DJANGO_PYOIDC, see :ref:`Configuring django_rest_framework` for more details). You can also activate it for more classical providers. But in DRF mode the ``access_token`` is the only information you receive from the user, and you need to extract claims from the token, that's why we use introspection to both validate the token and get more informations from it.
+This setting is enabled by default on Django Rest Framework authentication (when you use drf for the key in DJANGO_PYOIDC, see :ref:`Configuring django_rest_framework` for more details). You can also activate it for more classical providers. But in DRF mode the ``access_token`` is the only information you receive from the user, and you need to extract claims from the token, that's why we use introspection to both validate the token and get more information from it.
 
 When this setting is enabled, we will use the *introspection endpoint* of the
 identity provider to perform token validation and return a clear extraction of the ``access_token``.
 
-When disabled the access token claims are not extracted, you only have the ``access_token`` in its JWT encoded format. You can then decide to try an extraction on your own with a jwt library, or keep it as a JWT. If your SSO provider provides enough claims in the userinfo token you do not need to extract content from the ``access_token``. That's why we do not extract the ``access_token`` claims by default. If you need informations from the ``access_token`` activating this setting will add a round trip to the SSO server, but at the end you'll have all the ``access_tokens`` claims in clear text.
+When disabled the access token claims are not extracted, you only have the ``access_token`` in its JWT encoded format. You can then decide to try an extraction on your own with a jwt library, or keep it as a JWT. If your SSO provider provides enough claims in the userinfo token you do not need to extract content from the ``access_token``. That's why we do not extract the ``access_token`` claims by default. If you need information from the ``access_token`` activating this setting will add a round trip to the SSO server, but at the end you'll have all the ``access_tokens`` claims in clear text.
 
 oidc_paths_prefix
 *****************
@@ -187,7 +187,7 @@ cache_django_backend
 ********************
 
 This setting configures the cache backend that is used to store OIDC sessions details. It should be
-the name of a cache defined in the ``CACHES` django settings.
+the name of a cache defined in the ``CACHES`` django setting.
 You can read more about *Cache Management* :ref:`here <expl_cache>`.
 
 .. _settings_hook:
@@ -195,7 +195,7 @@ You can read more about *Cache Management* :ref:`here <expl_cache>`.
 Hooks
 =====
 
-Hook settings are path to a python function that should be called in specific context. We use a custom syntax to reference a function of a module.
+Each hook setting is a path to a python function that should be called in a specific context. We use a custom syntax to reference a function of a module.
 
 The syntax is : ``<module path>:<function name>``.
 
@@ -207,7 +207,7 @@ So for example, if you were to have a module named ``oidc.py`` next to your proj
 
 
 .. note::
-    All those settings are optional
+    All of these settings are optional
 
 hook_user_logout
 ****************
@@ -224,7 +224,7 @@ If the user was logged in, you can get the user using ``request.user``.
 hook_user_login
 ****************
 
-Calls the provided function on user login. The functions is called if the login is successful.
+Calls the provided function on user login. The function is called if the login is successful.
 
 This function takes two parameters :
 
@@ -238,7 +238,7 @@ hook_get_user
 
 Calls the provided function on user login. It takes two parameters :
 
-* ``client`` : an instance of ``OIDClient`` that can be used to fetch the provider which authenticated the user
+* ``client`` : an instance of ``OIDCClient`` that can be used to fetch the provider which authenticated the user
 * ``tokens`` : a dict with four keys :
     * ``info_token_claims`` : the userinfo token (if available) as a dict
     * ``access_token_jwt`` : the access token in it's raw form, undecoded (jwt)

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -25,12 +25,12 @@ Identity provider configuration
 provider_class
 **************
 
-**Default** : "django_pyoidc.providers.Provider"
+**Default**: "django_pyoidc.providers.Provider"
 
 Use this setting to plug in a provider class that will be used to generate the settings of your identity provider.
-Some providers expect to receive custom arguments : you should define them as settings.
+Some providers expect to receive custom arguments: you should define them as settings.
 
-For example, the ``Keycloak10Provider`` can use two arguments : ``keycloak_base_uri`` and ``keycloak_realm``. If you wish to use them, define them in ``DJANGO_PYOIDC`` as your identity provider setting.
+For example, the ``Keycloak10Provider`` can use two arguments: ``keycloak_base_uri`` and ``keycloak_realm``. If you wish to use them, define them in ``DJANGO_PYOIDC`` as your identity provider setting.
 
 provider_discovery_uri
 **********************
@@ -59,7 +59,7 @@ This setting configures the client id used to authenticate your application with
 use_introspection_on_access_tokens
 **********************************
 
-**Default** : ``True``
+**Default**: ``True``
 
 This setting is enabled by default on Django Rest Framework authentication (when you use drf for the key in DJANGO_PYOIDC, see :ref:`Configuring django_rest_framework` for more details). You can also activate it for more classical providers. But in DRF mode the ``access_token`` is the only information you receive from the user, and you need to extract claims from the token, that's why we use introspection to both validate the token and get more information from it.
 
@@ -71,7 +71,7 @@ When disabled the access token claims are not extracted, you only have the ``acc
 oidc_paths_prefix
 *****************
 
-**Default** : dynamically computed using the name of your identity provider.
+**Default**: dynamically computed using the name of your identity provider.
 
 This is the prefix of the various url names created *automagically* by the OIDCHelper (when using get_urlpatterns). If not set it defaults to the op_name.
 
@@ -113,7 +113,7 @@ oidc_logout_query_string_redirect_parameter
 oidc_logout_query_string_extra_parameters_dict
 **********************************************
 
-**Default** : ``{}``
+**Default**: ``{}``
 
 All the key/values of this dictionary are used as http query params when performing a logout request
 to the identity provider.
@@ -121,7 +121,7 @@ to the identity provider.
 client_authn_method
 *******************
 
-**Default** : see ``oic/utils/authn/client.py:437``
+**Default**: see ``oic/utils/authn/client.py:437``
 
 Methods that the OIDC client can use to authenticate itself. It's a dictionary with method names as
 keys and method classes as values.
@@ -147,7 +147,7 @@ This setting configures where a user is redirected after successful SSO logout, 
 oidc_callback_path
 ******************
 
-**Default** : <op_name
+**Default**: <op_name
 
 This setting is used to reference the callback view that should be provided as the ``redirect_uri`` parameter of the *Authorization Code Flow*.
 
@@ -167,7 +167,7 @@ Cache
 oidc_cache_provider_metadata
 ****************************
 
-**Default** : ``False``
+**Default**: ``False``
 
 When this setting is enabled, we will cache the calls to the autoconfiguration endpoint of the OIDC
 identity provider.
@@ -175,7 +175,7 @@ identity provider.
 oidc_cache_provider_metadata_ttl
 ********************************
 
-**Default** : ``120``
+**Default**: ``120``
 
 
 This settings has no effect if ``oidc_cache_provider_metadata`` is disabled.
@@ -197,7 +197,7 @@ Hooks
 
 Each hook setting is a path to a python function that should be called in a specific context. We use a custom syntax to reference a function of a module.
 
-The syntax is : ``<module path>:<function name>``.
+The syntax is: ``<module path>:<function name>``.
 
 
 So for example, if you were to have a module named ``oidc.py`` next to your project settings with a function called ``logout_callback`` you should use the string ``<your application root module>.oidc:logout_callback`` in your settings.
@@ -214,7 +214,7 @@ hook_user_logout
 
 Calls the provided function on user logout. The function is called if the logout is successful, but before redirecting the user.
 
-This function takes two named parameters :
+This function takes two named parameters:
 
 1. a request instance :class:`django:django.http.HttpRequest`
 2. the request args sent to the sso server (missing the id_token_hint element)
@@ -226,7 +226,7 @@ hook_user_login
 
 Calls the provided function on user login. The function is called if the login is successful.
 
-This function takes two parameters :
+This function takes two parameters:
 
 1. a request instance :class:`django:django.http.HttpRequest`
 2. a user instance :class:`django.contrib.auth.models.User`
@@ -236,13 +236,13 @@ Since the user wasn't logged in, it is not yet attached to the request instance 
 hook_get_user
 *************
 
-Calls the provided function on user login. It takes two parameters :
+Calls the provided function on user login. It takes two parameters:
 
-* ``client`` : an instance of ``OIDCClient`` that can be used to fetch the provider which authenticated the user
-* ``tokens`` : a dict with four keys :
-    * ``info_token_claims`` : the userinfo token (if available) as a dict
-    * ``access_token_jwt`` : the access token in it's raw form, undecoded (jwt)
-    * ``access_token_claims`` : the access token decoded, as a dict
-    * ``id_token_claims`` : the id token as a dict
+* ``client``: an instance of ``OIDCClient`` that can be used to fetch the provider which authenticated the user
+* ``tokens``: a dict with four keys:
+    * ``info_token_claims``: the userinfo token (if available) as a dict
+    * ``access_token_jwt``: the access token in it's raw form, undecoded (jwt)
+    * ``access_token_claims``: the access token decoded, as a dict
+    * ``id_token_claims``: the id token as a dict
 
 It is expected to return a :class:`django.contrib.auth.models.User` instance.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -7,7 +7,7 @@ a single-sign-on system. For the purpose of this tutorial, we will use Keycloak 
 Requirements
 ~~~~~~~~~~~~
 
-To use this library, make sure that you meet the following requirements :
+To use this library, make sure that you meet the following requirements:
 
 - ``django>=4.2``
 - ``python>=3.8``
@@ -60,11 +60,11 @@ Click on save and your client should be visible in the client list.
 
 You can now configure your URLs. In the following example, the Django application is hosted at app.local:8082.
 
-We configure our client URLs as such :
+We configure our client URLs as such:
 
 * ``Root URL`` and ``Home URL`` redirects to the root of our application *http://app.local:8082*
 * With ``Valid redirect URIs`` we allow the user to be redirected to our application, or the one listening on ``localhost:9091`` and ``127.0.0.1:9091`` (for debug purposes)
-* With ``Valid post logout redirect URIs`` the user can be redirected to our application after logout : *http://app.local:8082/**
+* With ``Valid post logout redirect URIs`` the user can be redirected to our application after logout: *http://app.local:8082/**
 * ``Web origins`` is set to *+* which allows (through CORS) all origins from the redirect URIs
 
 TODO: using a 2nd app at localhost:9091 is confusing, remove that, use a localhost:something, better
@@ -80,7 +80,7 @@ Take note of your ``Client ID`` and visit the *Credentials Page* to find your ``
 Finally, click on ``Realm Settings`` in the left menu, and scroll down to the *Endpoints* section. Copy the
 ``OpenID Endpoint Configuration`` URL as you will need it later (this is the autodiscovery URL).
 
-Congratulation, your Keycloak configuration is complete ! 🎉
+Congratulation, your Keycloak configuration is complete! 🎉
 
 Other Identity provider
 ***********************
@@ -94,7 +94,7 @@ Install the application
 It is now time to configure your Django project.
 
 
-First, add the library app (``django_pyoidc``) to your django applications, after `django.contrib.sessions` and `django.contrib.auth` :
+First, add the library app (``django_pyoidc``) to your django applications, after `django.contrib.sessions` and `django.contrib.auth`:
 
 .. code-block:: python
     :caption: settings.py
@@ -107,15 +107,15 @@ First, add the library app (``django_pyoidc``) to your django applications, afte
     ]
 
 .. warning::
-    Do not forget later to run the **migrations** ! This module requires some extra database storage tables.
+    Do not forget later to run the **migrations**! This module requires some extra database storage tables.
 
 Configure a cache backend
 *************************
 
-**You must have a cache backend** for this library to work ! The OIDC protocol is very stateful and we use Django cache system to store data.
+**You must have a cache backend** for this library to work! The OIDC protocol is very stateful and we use Django cache system to store data.
 If you want to understand why, you can read the :ref:`Cache management <expl_cache>` page.
 
-For the sake of this tutorial, you can use this cache management snippet (it should be pasted in your ``settings.py``) :
+For the sake of this tutorial, you can use this cache management snippet (it should be pasted in your ``settings.py``):
 
 .. code-block:: python
 
@@ -127,7 +127,7 @@ For the sake of this tutorial, you can use this cache management snippet (it sho
     }
 
 .. warning::
-    Do not use those settings in production ! Go read the `django documentation <https://docs.djangoproject.com/en/stable/topics/cache/#setting-up-the-cache>`_ for more details.
+    Do not use those settings in production! Go read the `django documentation <https://docs.djangoproject.com/en/stable/topics/cache/#setting-up-the-cache>`_ for more details.
 
 .. _tuto_settings:
 
@@ -138,16 +138,16 @@ First, make sure that the `Session middleware <https://docs.djangoproject.com/en
 
 We will use django_pyoidc provider system to generate the library configuration and views.
 
-When using provider, you must provide 4 settings :
+When using provider, you must provide 4 settings:
 
 - the provider class to use
-- the OIDC client ID : this is your identifier on the IP side (this is not a user account, this must be a *client* in the OIDC terminology)
-- the OIDC client secret : this is your secret on the IP side
-- the OIDC discovery URL : this url allows us to discover the various endpoint of the identity provider, easing the configuration
+- the OIDC client ID: this is your identifier on the IP side (this is not a user account, this must be a *client* in the OIDC terminology)
+- the OIDC client secret: this is your secret on the IP side
+- the OIDC discovery URL: this url allows us to discover the various endpoint of the identity provider, easing the configuration
 
 You must also define a provider name that will be used with other classes from this library. In the following
 example, we define a provider named *sso* which uses ``Keycloak18Provider`` and fetches it's credential from
-two environment variables :
+two environment variables:
 
 
 .. code-block:: python
@@ -187,7 +187,7 @@ generate views.
 
 To use it, you must instantiate it with ``op_name=<the name of your identity provider>``.
 
-Here is how to do it for our tutorial :
+Here is how to do it for our tutorial:
 
 .. code-block:: python
     :caption: urls.py
@@ -223,7 +223,7 @@ You should now be able to use the view names from this library to redirect the u
 Configuring django_rest_framework
 =================================
 
-When using OIDC to authenticate an API, things are a little bit different than on a **full stack** website :
+When using OIDC to authenticate an API, things are a little bit different than on a **full stack** website:
 
 * we do not want to redirect users on login pages, or to manage logout
 * we are receiving OIDC Bearer tokens -- access tokens-- (generated from other clients of the SSO) and the task is mainly to check that this token is valid and extract the user from it.
@@ -251,7 +251,7 @@ is similar to the one made in :ref:`Configure the library`.
     Usually your application should request a different *client_id* for the apimode (like a **my-app-full** *client_id* for a confidential classical OIDC client and a **my-app-api** *client_id* for a bearer-only OIDC client in Keycloak). But if you have only one *client_id* it's OK to simply make a copy for the settings.
 
 
-Once you declared those settings, you can configure ``DEFAULT_AUTHENTICATION_CLASSES`` to use ``django_pyoidc.drf.authentication.OIDCBearerAuthentication`` to use this authentication class on all your views :
+Once you declared those settings, you can configure ``DEFAULT_AUTHENTICATION_CLASSES`` to use ``django_pyoidc.drf.authentication.OIDCBearerAuthentication`` to use this authentication class on all your views:
 
 .. code-block:: python
     :caption: settings.py
@@ -262,14 +262,14 @@ Once you declared those settings, you can configure ``DEFAULT_AUTHENTICATION_CLA
         ]
     }
 
-You can also set this class on a per-view basis using the ``authentication_classes`` attribute :
+You can also set this class on a per-view basis using the ``authentication_classes`` attribute:
 
 .. code-block:: python
     :caption: views.py
 
     from django_pyoidc.drf.authentication import OIDCBearerAuthentication
 
-    class ExampleViewSet(ModelViewSet) :
+    class ExampleViewSet(ModelViewSet):
         authentication_classes = [OIDCBearerAuthentication]
 
 This class looks up the OIDC provider named ``drf`` in the ``DJANGO_PYOIDC`` setting. As such, you can only have one provider for all your API authentication, as you can not define

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -33,7 +33,7 @@ Next, you should configure a client in your identity provider configuration inte
     Incorrect configuration of your Identity Provider can create security issues. Please make sure you understand the values you input
     and their impact on the security level of your system.
 
-We provide instructions for `Keycloak <https://www.keycloak.org/>`_ (version 18 and more), a free and open source Identity Provider maintened by Red Hat.
+We provide instructions for `Keycloak <https://www.keycloak.org/>`_ (version 18 and more), a free and open source Identity Provider maintained by Red Hat.
 
 Keycloak
 ********
@@ -77,8 +77,8 @@ Take note of your ``Client ID`` and visit the *Credentials Page* to find your ``
 .. image:: images/keycloak/keycloak_client_secret.png
     :alt: Screenshot of the Credentials page from a test client
 
-Finally, click on ``Realm Settings`` in the left menu, and scroll down to the *Endpoints* section. Copy the ``
-OpenID Endpoint Configuration`` URL as you will need it later (this is the autodiscovery URL).
+Finally, click on ``Realm Settings`` in the left menu, and scroll down to the *Endpoints* section. Copy the
+``OpenID Endpoint Configuration`` URL as you will need it later (this is the autodiscovery URL).
 
 Congratulation, your Keycloak configuration is complete ! 🎉
 
@@ -94,7 +94,7 @@ Install the application
 It is now time to configure your Django project.
 
 
-First, add the library app (``django-pyoidc``) to your django applications, after `django.contrib.sessions` and `django.contrib.auth` :
+First, add the library app (``django_pyoidc``) to your django applications, after `django.contrib.sessions` and `django.contrib.auth` :
 
 .. code-block:: python
     :caption: settings.py
@@ -112,7 +112,7 @@ First, add the library app (``django-pyoidc``) to your django applications, afte
 Configure a cache backend
 *************************
 
-**You must have a cache backend** for this library to work ! The OIDC protocol is very statefull and we use Django cache system to store data.
+**You must have a cache backend** for this library to work ! The OIDC protocol is very stateful and we use Django cache system to store data.
 If you want to understand why, you can read the :ref:`Cache management <expl_cache>` page.
 
 For the sake of this tutorial, you can use this cache management snippet (it should be pasted in your ``settings.py``) :
@@ -172,7 +172,7 @@ two environment variables :
         },
 
 
-When you need to configure a setting for your identity provider, it means that you have to update the  dictionnary in this setting. For example, if you were to configure ``oidc_paths_prefix`` for your Keycloak provider,  you would add ``oidc_paths_prefix : <your value>`` to the ``sso`` dictionnary.
+When you need to configure a setting for your identity provider, it means that you have to update the dictionary in this setting. For example, if you were to configure ``oidc_paths_prefix`` for your Keycloak provider,  you would add ``oidc_paths_prefix : <your value>`` to the ``sso`` dictionary.
 
 Please note that ``drf`` is a reserved provider name (see :ref:`Configuring django_rest_framework` for more details)
 
@@ -213,7 +213,7 @@ This will create 4 views in your URL configuration. They all have a name that de
 
 .. tip::
 
-    You can override the naming behaviour by configuring the setting ``oidc_paths_prefix`` of your
+    You can override the naming behavior by configuring the setting ``oidc_paths_prefix`` of your
     identity provider. The view names would then be ``<oidc_paths_prefix>_<view_name>``.
 
 You should now be able to use the view names from this library to redirect the user to a login/logout page.


### PR DESCRIPTION
Fixes a bunch of spelling/grammar issues, makes punctuation spacing more proper for English, and improves correctness of `hook_get_user` examples.