### PR TITLE
fix : drf, add parameter to enable/disable audience check on introspection response

### DIFF
--- a/django_pyoidc/drf/authentication.py
+++ b/django_pyoidc/drf/authentication.py
@@ -94,12 +94,12 @@ class OIDCBearerAuthentication(BaseAuthentication):
             if access_token_claims:
                 logger.debug("Request has valid access token.")
 
-                # FIXME: Add a setting to disable
-                client_id: str = self.opsettings.get("client_id")  # type: ignore[assignment] # we can assume that client_id is correctly configured
-                if not check_audience(client_id, access_token_claims):
-                    raise PermissionDenied(
-                        f"Invalid result for acces token audiences check for {client_id}."
-                    )
+                if self.opsettings.get("use_introspection_audience_check"):
+                    client_id: str = self.opsettings.get("client_id")  # type: ignore[assignment] # we can assume that client_id is correctly configured
+                    if not check_audience(client_id, access_token_claims):
+                        raise PermissionDenied(
+                            f"Invalid result for acces token audiences check for {client_id}."
+                        )
 
                 logger.debug("Let application load user via user hook.")
                 user = self.engine.call_get_user_function(

--- a/django_pyoidc/settings.py
+++ b/django_pyoidc/settings.py
@@ -21,6 +21,7 @@ TypedOidcSettings = TypedDict(
         "oidc_cache_provider_metadata": bool,
         "oidc_cache_provider_metadata_ttl": int,
         "use_introspection_on_access_tokens": bool,
+        "use_introspection_audience_check": bool,
     },
 )
 
@@ -34,6 +35,7 @@ class OIDCSettings:
         "oidc_cache_provider_metadata": False,
         "oidc_cache_provider_metadata_ttl": 120,
         "use_introspection_on_access_tokens": True,
+        "use_introspection_audience_check": True,
     }
 
     def __repr__(self) -> str:
@@ -83,6 +85,8 @@ class OIDCSettings:
                 the introspection route. This delegates validation of the token to the SSO server. If you do not use hook_validate_access_token
                 or use_introspection_on_access_tokens you will just have the raw jwt for the access token, that you can use to send HTTP queries
                 on behalf of the user.
+               use_introspection_audience_check (bool): when use_introspection_on_access_tokens in True, check the client id in audience return
+                by the introspection response.
         """
 
         self.op_name = op_name

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -126,6 +126,22 @@ client_authn_method
 Methods that the OIDC client can use to authenticate itself. It's a dictionary with method names as
 keys and method classes as values.
 
+
+use_introspection_audience_check
+********************************
+
+**Default**: ``True``
+
+This setting allows you to disable the audience check.
+
+This settings is related to the drf implementation. By default, this library performs audience
+checks against the token received.
+We look for an ``aud`` key in the received token, and check that it's value is the same as our
+client ID.
+
+**We believe that the only use case for this settings is if your identity provider does not put the
+audience in the generated tokens.**
+
 Login/Logout redirections
 =========================
 


### PR DESCRIPTION
Hello

Proposition of a fix to add a parameter to enable / disable audience check on introspection response in drf.

I will use that library in my company to connect a project using django rest framework to an sso provider. Our SSO provider doesn't put the `aud` property in the introspection response.

Thank you