### PR TITLE
Fix LoginRequiredMiddleware was unusable with django pyoidc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ NEXT
 ----
 - drop support for python 3.8
 - drop support for python 3.9
-
+- fix LoginRequiredMiddleware was unusable with django pyoidc (#78)
 
 1.0.12
 ------

--- a/django_pyoidc/views.py
+++ b/django_pyoidc/views.py
@@ -5,6 +5,7 @@ import jwt
 
 # import oic
 from django.contrib import auth, messages
+from django.contrib.auth.decorators import login_not_required
 from django.contrib.auth.models import AbstractUser
 from django.core.exceptions import PermissionDenied, SuspiciousOperation
 from django.http import HttpRequest, HttpResponse
@@ -95,6 +96,10 @@ class OIDCView(View, OIDCMixin):
         return None
 
 
+@method_decorator(
+    login_not_required,
+    name="dispatch",
+)
 class OIDCLoginView(OIDCView):
     """
     When receiving a GET request, this views redirects the user to the SSO identified by `op_name`.
@@ -248,6 +253,10 @@ class OIDCLogoutView(OIDCView):
             return redirect(post_logout_url)
 
 
+@method_decorator(
+    login_not_required,
+    name="dispatch",
+)
 @method_decorator(csrf_exempt, name="dispatch")
 class OIDCBackChannelLogoutView(OIDCView):
     """
@@ -314,6 +323,10 @@ class OIDCBackChannelLogoutView(OIDCView):
         return result
 
 
+@method_decorator(
+    login_not_required,
+    name="dispatch",
+)
 class OIDCCallbackView(OIDCView):
     """
     This view only accepts GET request. This is where the identity provider redirects the user in the *Authorization Code Flow*.

--- a/tests/tests_views.py
+++ b/tests/tests_views.py
@@ -160,10 +160,7 @@ class LoginViewTestCase(OIDCTestCase):
 
     @mock.patch("django_pyoidc.client.Consumer.provider_config")
     @mock.patch("django_pyoidc.client.Consumer.begin", return_value=(1, "/"))
-    @override_settings(
-        MIDDLEWARE=settings.MIDDLEWARE
-        + ["django.contrib.auth.middleware.LoginRequiredMiddleware"]
-    )
+    @override_settings(MIDDLEWARE=[*settings.MIDDLEWARE, "django.contrib.auth.middleware.LoginRequiredMiddleware"])
     def test_scope_is_set(self, mocked_begin: MagicMock, *args):
         response = self.client.get(
             reverse("test_login"),
@@ -177,9 +174,7 @@ class LoginViewTestCase(OIDCTestCase):
         self.assertEqual(response.status_code, 302)
         mocked_begin.assert_called_once_with(scope=["openid"], response_type=ANY, use_nonce=ANY, path=ANY)
 
-    @override_settings(
-        MIDDLEWARE=["django.contrib.auth.middleware.LoginRequiredMiddleware"]
-    )
+    @override_settings(MIDDLEWARE=["django.contrib.auth.middleware.LoginRequiredMiddleware"])
     def test_login_required_middleware(self):
         """
         Ensures that the login view does not need authentication when using
@@ -501,9 +496,7 @@ class CallbackViewTestCase(OIDCTestCase):
         self.assertEqual(OIDCSession.objects.all().count(), 0)
         mocked_user_access_token_hook.assert_called_once()
 
-    @override_settings(
-        MIDDLEWARE=["django.contrib.auth.middleware.LoginRequiredMiddleware"]
-    )
+    @override_settings(MIDDLEWARE=["django.contrib.auth.middleware.LoginRequiredMiddleware"])
     def test_callback_required_middleware(self):
         """
         Ensures that the callback view does not need authentication when using
@@ -737,9 +730,7 @@ class BackchannelLogoutTestCase(OIDCTestCase):
             view._logout_session("test")
         mocked_call_function.assert_called_once_with("hook_session_logout", session="test")
 
-    @override_settings(
-        MIDDLEWARE=["django.contrib.auth.middleware.LoginRequiredMiddleware"]
-    )
+    @override_settings(MIDDLEWARE=["django.contrib.auth.middleware.LoginRequiredMiddleware"])
     def test_login_required_middleware(self):
         """
         Ensures that the backchannel logout view does not need authentication when using

--- a/tests/tests_views.py
+++ b/tests/tests_views.py
@@ -5,13 +5,18 @@ from unittest.mock import ANY, MagicMock, call
 import jwt
 from django.conf import settings
 from django.contrib.auth import SESSION_KEY, get_user_model
+from django.test import override_settings
 from django.urls import reverse
 from oic.oic import IdToken
 from oic.oic.message import OpenIDSchema
 
 from django_pyoidc.client import OIDCClient
 from django_pyoidc.models import OIDCSession
-from django_pyoidc.views import OIDCBackChannelLogoutView
+from django_pyoidc.views import (
+    OIDCBackChannelLogoutView,
+    OIDCCallbackView,
+    OIDCLoginView,
+)
 from tests.utils import OIDCTestCase
 
 SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
@@ -155,6 +160,10 @@ class LoginViewTestCase(OIDCTestCase):
 
     @mock.patch("django_pyoidc.client.Consumer.provider_config")
     @mock.patch("django_pyoidc.client.Consumer.begin", return_value=(1, "/"))
+    @override_settings(
+        MIDDLEWARE=settings.MIDDLEWARE
+        + ["django.contrib.auth.middleware.LoginRequiredMiddleware"]
+    )
     def test_scope_is_set(self, mocked_begin: MagicMock, *args):
         response = self.client.get(
             reverse("test_login"),
@@ -167,6 +176,17 @@ class LoginViewTestCase(OIDCTestCase):
         )
         self.assertEqual(response.status_code, 302)
         mocked_begin.assert_called_once_with(scope=["openid"], response_type=ANY, use_nonce=ANY, path=ANY)
+
+    @override_settings(
+        MIDDLEWARE=["django.contrib.auth.middleware.LoginRequiredMiddleware"]
+    )
+    def test_login_required_middleware(self):
+        """
+        Ensures that the login view does not need authentication when using
+        LoginRequiredMiddleware.
+        """
+        view = OIDCLoginView(op_name="sso1")
+        self.assertFalse(view.dispatch.login_required)
 
 
 class LogoutViewTestCase(OIDCTestCase):
@@ -481,6 +501,17 @@ class CallbackViewTestCase(OIDCTestCase):
         self.assertEqual(OIDCSession.objects.all().count(), 0)
         mocked_user_access_token_hook.assert_called_once()
 
+    @override_settings(
+        MIDDLEWARE=["django.contrib.auth.middleware.LoginRequiredMiddleware"]
+    )
+    def test_callback_required_middleware(self):
+        """
+        Ensures that the callback view does not need authentication when using
+        LoginRequiredMiddleware.
+        """
+        view = OIDCCallbackView(op_name="sso1")
+        self.assertFalse(view.dispatch.login_required)
+
 
 class BackchannelLogoutTestCase(OIDCTestCase):
     @classmethod
@@ -705,3 +736,14 @@ class BackchannelLogoutTestCase(OIDCTestCase):
         with mock.patch("django_pyoidc.views.OIDCView.call_function") as mocked_call_function:
             view._logout_session("test")
         mocked_call_function.assert_called_once_with("hook_session_logout", session="test")
+
+    @override_settings(
+        MIDDLEWARE=["django.contrib.auth.middleware.LoginRequiredMiddleware"]
+    )
+    def test_login_required_middleware(self):
+        """
+        Ensures that the backchannel logout view does not need authentication when using
+        LoginRequiredMiddleware.
+        """
+        view = OIDCBackChannelLogoutView(op_name="sso1")
+        self.assertFalse(view.dispatch.login_required)


### PR DESCRIPTION
solves https://github.com/makinacorpus/django_pyoidc/issues/78